### PR TITLE
Replace matplotlib.image with PIL.Image

### DIFF
--- a/transcribebot.py
+++ b/transcribebot.py
@@ -87,6 +87,8 @@ class MyClient(discord.Client):
             for attachment in attachments:
                 # Check if the attachment is an image
                 if attachment.content_type.startswith('image'):
+                    # Download the image
+                    await attachment.save(attachment.filename)
                     # Read the image
                     with Image.open(attachment.filename) as image:
                         # if the image is RGBA, convert it to RGB


### PR DESCRIPTION
This is recommended by the matplotlib documentation, and fixes an issue when the filename and MIME type mismatch. I believe this should also mean matplotlib is no longer a requirement.